### PR TITLE
fix parse_history regex when sequence exeeds 9999

### DIFF
--- a/recent2.py
+++ b/recent2.py
@@ -120,7 +120,7 @@ def migrate(version, conn):
 
 
 def parse_history(history):
-    match = re.search(r'^\s+(\d+)\s+(.*)$', history,
+    match = re.search(r'^\s*(\d+)\s+(.*)$', history,
                       re.MULTILINE and re.DOTALL)
     if match:
         return match.group(1), match.group(2)


### PR DESCRIPTION
Match zero or more characters of whitespace at the beginning of lines when parsing `history 1` output.

This fixed my issue where the `parse_history` function stopped working once my history reached 10000 lines.