### PR TITLE
Add Zsh support for command logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,66 @@ Add the following to your `.bashrc` or `.bash_profile`.
 
 And start a new shell.
 
+### For Zsh Users
+
+Recent2 can also be integrated with Zsh. You'll need to add a couple of functions to your `.zshrc` to use Zsh's `precmd` and `preexec` hooks.
+
+1.  **Ensure `log-recent` is in your PATH.** This is typically handled by pip installation.
+2.  **Add the following to your `~/.zshrc`:**
+
+```zsh
+# recent2 Zsh Integration
+autoload -U add-zsh-hook
+
+_recent2_preexec() {
+  if [[ -n "$3" ]]; then
+    _RECENT2_CURRENT_COMMAND_TEXT="$3"
+    _RECENT2_CURRENT_COMMAND_SEQ="$HISTCMD"
+  else
+    unset _RECENT2_CURRENT_COMMAND_TEXT
+    unset _RECENT2_CURRENT_COMMAND_SEQ
+  fi
+}
+
+_recent2_precmd() {
+  if [[ -n "$_RECENT2_CURRENT_COMMAND_TEXT" && -n "$_RECENT2_CURRENT_COMMAND_SEQ" ]]; then
+    local return_status=$?
+    if command -v log-recent &>/dev/null; then
+      log-recent --shell zsh \
+                 -r "$return_status" \
+                 -p "$$" \
+                 --raw_command_text "$_RECENT2_CURRENT_COMMAND_TEXT" \
+                 --sequence_num "$_RECENT2_CURRENT_COMMAND_SEQ"
+    else
+      if [[ -z "$_RECENT2_LOG_RECENT_WARNING_SHOWN" ]]; then
+        echo "recent2: log-recent command not found. Please ensure it's in your PATH." >&2
+        _RECENT2_LOG_RECENT_WARNING_SHOWN=1
+      fi
+    fi
+    unset _RECENT2_CURRENT_COMMAND_TEXT
+    unset _RECENT2_CURRENT_COMMAND_SEQ
+  fi
+}
+
+if [[ -z "${precmd_functions[(r)_recent2_precmd]}" ]]; then
+  add-zsh-hook precmd _recent2_precmd
+fi
+
+if [[ -z "${preexec_functions[(r)_recent2_preexec]}" ]]; then
+  add-zsh-hook preexec _recent2_preexec
+fi
+# End of recent2 Zsh Integration
+```
+
+3.  **Start a new Zsh shell.**
+
+This setup uses:
+*   `_recent2_preexec`: Captures the command text (from `$3`) and its history number (`HISTCMD`) before execution.
+*   `_recent2_precmd`: Calls `log-recent` with the captured details and exit status (`$?`) after the command finishes but before the prompt is displayed.
+*   `add-zsh-hook`: Safely adds these functions to Zsh's hook arrays.
+
+Alternatively, you can find this snippet in the `recent2_zsh_setup.sh` file in the repository and source it if you prefer.
+
 ## Usage
 
 See example usage at https://asciinema.org/a/271533

--- a/recent2.py
+++ b/recent2.py
@@ -28,9 +28,7 @@ class Term:
 
 
 EXPECTED_BASH_PROMPT_COMMAND = 'log-recent -r $? -c "$(HISTTIMEFORMAT= history 1)" -p $$'
-# For zsh, we'll expect users to set up precmd and preexec functions.
-# We can't easily check the exact content of these functions from here,
-# so we'll rely on RECENT_SHELL_INTEGRATION_CHECK_OFF to disable the check if needed.
+
 
 class DB:
     SCHEMA_VERSION = 2
@@ -271,52 +269,19 @@ def log(args_for_test=None):
                         help='Command return value. Set to $?',
                         default=0,
                         type=int)
-    parser.add_argument('-c', '--command', help='For bash: Set to $(HISTTIMEFORMAT= history 1). For zsh: Set to the captured command string.', default='')
+    parser.add_argument('-c', '--command', help='Set to $(HISTTIMEFORMAT= history 1)', default='')
     parser.add_argument('-p', '--pid', help='Shell pid. Set to $$', default=0, type=int)
-    parser.add_argument('--shell', help='Calling shell type (e.g., bash, zsh)', default='bash') # Add shell type
-    parser.add_argument('--sequence_num', help='History sequence number (primarily for zsh if passed directly)', type=int, default=None)
-    parser.add_argument('--raw_command_text', help='Direct command text (primarily for zsh)', type=str, default=None)
-
     args = parser.parse_args(args_for_test)
 
+    sequence, command = parse_history(args.command)
     pid, return_value = args.pid, args.return_value
     pwd = os.getenv('PWD', '')
-    command_to_log = None
-    sequence_to_log = None
 
-    if args.shell == 'zsh':
-        if args.raw_command_text is not None and args.sequence_num is not None:
-            command_to_log = args.raw_command_text
-            sequence_to_log = args.sequence_num
-        else:
-            # Zsh should provide raw_command_text and sequence_num
-            print(Term.WARNING + ('recent: zsh integration expects --raw_command_text and --sequence_num.') + Term.ENDC)
-            # Potentially fall back to parsing args.command if zsh history -1 format is compatible and passed via -c
-            # For now, we'll be strict.
-            if not args.raw_command_text:
-                 print(Term.FAIL + ('recent: --raw_command_text is missing for zsh.') + Term.ENDC)
-                 sys.exit(1)
-            if args.sequence_num is None:
-                 print(Term.FAIL + ('recent: --sequence_num is missing for zsh.') + Term.ENDC)
-                 sys.exit(1)
-            return # Should not happen if zsh functions are set up correctly
-
-    elif args.shell == 'bash':
-        sequence_to_log, command_to_log = parse_history(args.command)
-        if not sequence_to_log or not command_to_log:
-            print(Term.WARNING + ('recent: cannot parse bash command output, please check your '
-                                  'trigger looks like this:') + Term.ENDC)
-            exit("""export PROMPT_COMMAND='{}'""".format(EXPECTED_BASH_PROMPT_COMMAND))
-    else:
-        print(Term.FAIL + ('recent: unsupported shell type "{}".'.format(args.shell)) + Term.ENDC)
-        sys.exit(1)
-
-    if command_to_log is None or sequence_to_log is None:
-        # This case should ideally be caught by shell-specific checks above
-        print(Term.FAIL + "recent: Failed to determine command or sequence number." + Term.ENDC)
-        sys.exit(1)
-
-    log_command(command=command_to_log, pid=pid, sequence=sequence_to_log, return_value=return_value, pwd=pwd)
+    if not sequence or not command:
+        print(Term.WARNING + ('recent: cannot parse command output, please check your bash '
+                              'trigger looks like this:') + Term.ENDC)
+        exit("""export PROMPT_COMMAND='{}'""".format(EXPECTED_PROMPT))
+    log_command(command=command, pid=pid, sequence=sequence, return_value=return_value, pwd=pwd)
 
 
 def log_command(command, pid, sequence, return_value, pwd):
@@ -571,37 +536,28 @@ def make_arg_parser_for_recent():
 
 
 def check_prompt(debug):
-    # RECENT_SHELL_INTEGRATION_CHECK_OFF allows users to bypass this check if they have a custom setup.
     if os.environ.get('RECENT_SHELL_INTEGRATION_CHECK_OFF'):
         if debug:
-            print("RECENT_SHELL_INTEGRATION_CHECK_OFF is set. Not checking shell integration.")
+            print("recent2: RECENT_SHELL_INTEGRATION_CHECK_OFF is set. Skipping prompt check.")
         return
 
-    if os.environ.get('RECENT_CUSTOM_PROMPT'): # Legacy support for bash custom prompt
+    if os.environ.get('RECENT_CUSTOM_PROMPT'):  # Legacy support for bash custom prompt
         if debug:
-            print("RECENT_CUSTOM_PROMPT is set (legacy). Not checking prompt for bash.")
+            print("recent2: RECENT_CUSTOM_PROMPT is set (legacy). Skipping PROMPT_COMMAND check for bash.")
         return
 
     current_shell = os.path.basename(os.environ.get('SHELL', ''))
 
     if 'bash' in current_shell:
         actual_prompt = os.environ.get('PROMPT_COMMAND', '')
-        export_prompt_cmd = '''export PROMPT_COMMAND='{}' '''.format(EXPECTED_BASH_PROMPT_COMMAND)
+        # Ensure EXPECTED_BASH_PROMPT_COMMAND is defined, using the one from global scope
         if EXPECTED_BASH_PROMPT_COMMAND not in actual_prompt:
-            print(Term.BOLD + "Bash PROMPT_COMMAND env variable is not correctly set for recent2. " +
-                  "Add the following line to .bashrc or .bash_profile" + Term.ENDC)
+            export_prompt_cmd = '''export PROMPT_COMMAND='{}' '''.format(EXPECTED_BASH_PROMPT_COMMAND)
+            print(Term.BOLD + "recent2: Bash PROMPT_COMMAND env variable is not correctly set. " +
+                  "Add the following line to .bashrc or .bash_profile:" + Term.ENDC)
             sys.exit(Term.UNDERLINE + export_prompt_cmd + Term.ENDC)
-    elif 'zsh' in current_shell:
-        # For Zsh, it's harder to check the precmd/preexec functions directly from Python.
-        # We'll rely on the user setting them up as per documentation.
-        # A simple check could be to see if _RECENT2_LAST_COMMAND is available if we decide to set it globally,
-        # but that's not robust.
-        # For now, we'll just print a reminder if debug is on.
-        if debug:
-            print(Term.OKBLUE + "recent2: Ensure zsh precmd and preexec functions for recent2 are correctly set up in your .zshrc." + Term.ENDC)
-    # else:
-        # Potentially handle other shells or print a generic message.
-        # For now, we only explicitly support bash and zsh for this check.
+    # For other shells like zsh, this function will do nothing,
+    # as their integration is handled differently (e.g., via .zshrc hooks).
 
 
 def tty_width():

--- a/recent2.py
+++ b/recent2.py
@@ -27,8 +27,10 @@ class Term:
     UNDERLINE = '\033[4m'
 
 
-EXPECTED_PROMPT = 'log-recent -r $? -c "$(HISTTIMEFORMAT= history 1)" -p $$'
-
+EXPECTED_BASH_PROMPT_COMMAND = 'log-recent -r $? -c "$(HISTTIMEFORMAT= history 1)" -p $$'
+# For zsh, we'll expect users to set up precmd and preexec functions.
+# We can't easily check the exact content of these functions from here,
+# so we'll rely on RECENT_SHELL_INTEGRATION_CHECK_OFF to disable the check if needed.
 
 class DB:
     SCHEMA_VERSION = 2
@@ -269,19 +271,52 @@ def log(args_for_test=None):
                         help='Command return value. Set to $?',
                         default=0,
                         type=int)
-    parser.add_argument('-c', '--command', help='Set to $(HISTTIMEFORMAT= history 1)', default='')
+    parser.add_argument('-c', '--command', help='For bash: Set to $(HISTTIMEFORMAT= history 1). For zsh: Set to the captured command string.', default='')
     parser.add_argument('-p', '--pid', help='Shell pid. Set to $$', default=0, type=int)
+    parser.add_argument('--shell', help='Calling shell type (e.g., bash, zsh)', default='bash') # Add shell type
+    parser.add_argument('--sequence_num', help='History sequence number (primarily for zsh if passed directly)', type=int, default=None)
+    parser.add_argument('--raw_command_text', help='Direct command text (primarily for zsh)', type=str, default=None)
+
     args = parser.parse_args(args_for_test)
 
-    sequence, command = parse_history(args.command)
     pid, return_value = args.pid, args.return_value
     pwd = os.getenv('PWD', '')
+    command_to_log = None
+    sequence_to_log = None
 
-    if not sequence or not command:
-        print(Term.WARNING + ('recent: cannot parse command output, please check your bash '
-                              'trigger looks like this:') + Term.ENDC)
-        exit("""export PROMPT_COMMAND='{}'""".format(EXPECTED_PROMPT))
-    log_command(command=command, pid=pid, sequence=sequence, return_value=return_value, pwd=pwd)
+    if args.shell == 'zsh':
+        if args.raw_command_text is not None and args.sequence_num is not None:
+            command_to_log = args.raw_command_text
+            sequence_to_log = args.sequence_num
+        else:
+            # Zsh should provide raw_command_text and sequence_num
+            print(Term.WARNING + ('recent: zsh integration expects --raw_command_text and --sequence_num.') + Term.ENDC)
+            # Potentially fall back to parsing args.command if zsh history -1 format is compatible and passed via -c
+            # For now, we'll be strict.
+            if not args.raw_command_text:
+                 print(Term.FAIL + ('recent: --raw_command_text is missing for zsh.') + Term.ENDC)
+                 sys.exit(1)
+            if args.sequence_num is None:
+                 print(Term.FAIL + ('recent: --sequence_num is missing for zsh.') + Term.ENDC)
+                 sys.exit(1)
+            return # Should not happen if zsh functions are set up correctly
+
+    elif args.shell == 'bash':
+        sequence_to_log, command_to_log = parse_history(args.command)
+        if not sequence_to_log or not command_to_log:
+            print(Term.WARNING + ('recent: cannot parse bash command output, please check your '
+                                  'trigger looks like this:') + Term.ENDC)
+            exit("""export PROMPT_COMMAND='{}'""".format(EXPECTED_BASH_PROMPT_COMMAND))
+    else:
+        print(Term.FAIL + ('recent: unsupported shell type "{}".'.format(args.shell)) + Term.ENDC)
+        sys.exit(1)
+
+    if command_to_log is None or sequence_to_log is None:
+        # This case should ideally be caught by shell-specific checks above
+        print(Term.FAIL + "recent: Failed to determine command or sequence number." + Term.ENDC)
+        sys.exit(1)
+
+    log_command(command=command_to_log, pid=pid, sequence=sequence_to_log, return_value=return_value, pwd=pwd)
 
 
 def log_command(command, pid, sequence, return_value, pwd):
@@ -536,16 +571,37 @@ def make_arg_parser_for_recent():
 
 
 def check_prompt(debug):
-    if os.environ.get('RECENT_CUSTOM_PROMPT'):
+    # RECENT_SHELL_INTEGRATION_CHECK_OFF allows users to bypass this check if they have a custom setup.
+    if os.environ.get('RECENT_SHELL_INTEGRATION_CHECK_OFF'):
         if debug:
-            print("RECENT_CUSTOM_PROMPT is set. Not checking prompt")
+            print("RECENT_SHELL_INTEGRATION_CHECK_OFF is set. Not checking shell integration.")
         return
-    actual_prompt = os.environ.get('PROMPT_COMMAND', '')
-    export_prompt_cmd = '''export PROMPT_COMMAND='{}' '''.format(EXPECTED_PROMPT)
-    if EXPECTED_PROMPT not in actual_prompt:
-        print(Term.BOLD + "PROMPT_COMMAND env variable is not set. " +
-              "Add the following line to .bashrc or .bash_profile" + Term.ENDC)
-        sys.exit(Term.UNDERLINE + export_prompt_cmd + Term.ENDC)
+
+    if os.environ.get('RECENT_CUSTOM_PROMPT'): # Legacy support for bash custom prompt
+        if debug:
+            print("RECENT_CUSTOM_PROMPT is set (legacy). Not checking prompt for bash.")
+        return
+
+    current_shell = os.path.basename(os.environ.get('SHELL', ''))
+
+    if 'bash' in current_shell:
+        actual_prompt = os.environ.get('PROMPT_COMMAND', '')
+        export_prompt_cmd = '''export PROMPT_COMMAND='{}' '''.format(EXPECTED_BASH_PROMPT_COMMAND)
+        if EXPECTED_BASH_PROMPT_COMMAND not in actual_prompt:
+            print(Term.BOLD + "Bash PROMPT_COMMAND env variable is not correctly set for recent2. " +
+                  "Add the following line to .bashrc or .bash_profile" + Term.ENDC)
+            sys.exit(Term.UNDERLINE + export_prompt_cmd + Term.ENDC)
+    elif 'zsh' in current_shell:
+        # For Zsh, it's harder to check the precmd/preexec functions directly from Python.
+        # We'll rely on the user setting them up as per documentation.
+        # A simple check could be to see if _RECENT2_LAST_COMMAND is available if we decide to set it globally,
+        # but that's not robust.
+        # For now, we'll just print a reminder if debug is on.
+        if debug:
+            print(Term.OKBLUE + "recent2: Ensure zsh precmd and preexec functions for recent2 are correctly set up in your .zshrc." + Term.ENDC)
+    # else:
+        # Potentially handle other shells or print a generic message.
+        # For now, we only explicitly support bash and zsh for this check.
 
 
 def tty_width():

--- a/recent2_zsh_setup.sh
+++ b/recent2_zsh_setup.sh
@@ -1,0 +1,106 @@
+# recent2 zsh setup
+#
+# To enable recent2 logging in zsh, add the following to your ~/.zshrc file:
+#
+# autoload -U add-zsh-hook
+#
+# _recent2_preexec() {
+#   # Capture command text. The third argument to preexec is the full command text.
+#   # Only store if it's not empty.
+#   if [[ -n "$3" ]]; then
+#       # Store the command text in a global variable.
+#       # Using a specific prefix to avoid clashes.
+#       _RECENT2_CURRENT_COMMAND_TEXT="$3"
+#
+#       # Try to get the history number. HISTCMD is the history number of the current command line.
+#       # This should be available before the command executes.
+#       _RECENT2_CURRENT_COMMAND_SEQ="$HISTCMD"
+#   else
+#       # Clear if no command text (e.g. just hitting enter on empty prompt)
+#       unset _RECENT2_CURRENT_COMMAND_TEXT
+#       unset _RECENT2_CURRENT_COMMAND_SEQ
+#   fi
+# }
+#
+# _recent2_precmd() {
+#   # Check if a command was captured by preexec
+#   if [[ -n "$_RECENT2_CURRENT_COMMAND_TEXT" && -n "$_RECENT2_CURRENT_COMMAND_SEQ" ]]; then
+#     local return_status=$?
+#     # Log the command using recent2's log function
+#     # Ensure log-recent is in your PATH
+#     if command -v log-recent &>/dev/null; then
+#       log-recent --shell zsh \
+#                  -r "$return_status" \
+#                  -p "$$" \
+#                  --raw_command_text "$_RECENT2_CURRENT_COMMAND_TEXT" \
+#                  --sequence_num "$_RECENT2_CURRENT_COMMAND_SEQ"
+#     else
+#       # Print a warning if log-recent is not found, but only once per session perhaps
+#       if [[ -z "$_RECENT2_LOG_RECENT_WARNING_SHOWN" ]]; then
+#         echo "recent2: log-recent command not found. Please ensure it's in your PATH." >&2
+#         _RECENT2_LOG_RECENT_WARNING_SHOWN=1
+#       fi
+#     fi
+#
+#     # Unset the global variables to prevent re-logging or issues
+#     unset _RECENT2_CURRENT_COMMAND_TEXT
+#     unset _RECENT2_CURRENT_COMMAND_SEQ
+#   fi
+# }
+#
+# # Add the functions to their respective hooks
+# # Ensure this is done only once to avoid duplicate entries if .zshrc is sourced multiple times
+# if [[ -z "${precmd_functions[(r)_recent2_precmd]}" ]]; then
+#   add-zsh-hook precmd _recent2_precmd
+# fi
+#
+# if [[ -z "${preexec_functions[(r)_recent2_preexec]}" ]]; then
+#   add-zsh-hook preexec _recent2_preexec
+# fi
+#
+# # End of recent2 zsh setup
+#
+# # You can also put the functions directly in your .zshrc if you prefer,
+# # instead of sourcing this file.
+# # Make sure recent2 is installed (pip install recent2) and log-recent is in your PATH.
+#
+# # Example of adding directly to .zshrc:
+# #
+# # autoload -U add-zsh-hook # Make sure this is near the top if not already present
+# #
+# # _recent2_preexec() { ... function body from above ... }
+# # _recent2_precmd() { ... function body from above ... }
+# #
+# # if [[ -z "${precmd_functions[(r)_recent2_precmd]}" ]]; then
+# #   add-zsh-hook precmd _recent2_precmd
+# # fi
+# # if [[ -z "${preexec_functions[(r)_recent2_preexec]}" ]]; then
+# #   add-zsh-hook preexec _recent2_preexec
+# # fi
+#
+#
+# # Notes on zsh history and sequence numbers:
+# # HISTCMD variable in zsh contains the history line number of the current command.
+# # This seems to be the most reliable way to get a sequence number that aligns with
+# # how zsh numbers history entries.
+# #
+# # The command text is captured from the 3rd argument to preexec_functions ($3),
+# # which zsh documentation states is the "full text that is being executed".
+# #
+# # `add-zsh-hook` is a helper function that safely adds a function to a hook array,
+# # avoiding duplicates. It requires `autoload -U add-zsh-hook`.
+#
+# # Ensure PWD is correctly reported
+# # By default, zsh's PWD should be fine. The log-recent script already captures PWD
+# # using os.getenv('PWD', '').
+#
+# # To use, source this file in your .zshrc:
+# # source /path/to/recent2_zsh_setup.sh
+# # Or copy the relevant parts directly into your .zshrc.
+
+# Make the script executable if someone tries to run it, though it's meant to be sourced or copied.
+if [ "$0" = "${BASH_SOURCE[0]}" ]; then
+    echo "This script is intended to be sourced by your .zshrc, or its contents copied into it."
+    echo "Example: source $0"
+    echo "Or, copy the function definitions and add-zsh-hook calls into your ~/.zshrc."
+fi


### PR DESCRIPTION
This commit introduces support for logging shell commands in Zsh alongside the existing Bash support.

Key changes:
- Modified `recent2.py` to handle different shell types (`bash`, `zsh`) via a `--shell` argument to `log-recent`.
- The `log-recent` command now accepts `--raw_command_text` and `--sequence_num` for direct input, primarily for Zsh integration.
- Updated `check_prompt` to be shell-aware and provide appropriate guidance.
- Created `recent2_zsh_setup.sh` containing Zsh `precmd` and `preexec` hook functions to capture command details and call `log-recent`.
- Updated `README.md` with detailed instructions for Zsh users, including the necessary `.zshrc` snippet.

Zsh integration uses `HISTCMD` for the sequence number and captures the full command text from the `preexec` hook arguments.